### PR TITLE
Use Gradle logger instead of sout

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,11 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="kotlin">

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ plugins {
 
 tracks {
     automatticProject.set(io.github.wzieba.tracks.plugin.TracksExtension.AutomatticProject.WooCommerce)
-    debug.set(true)
 }
 ```
 

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -6,6 +6,5 @@ plugins {
 tracks {
     automatticProject.set(io.github.wzieba.tracks.plugin.TracksExtension.AutomatticProject.WooCommerce)
     customEventName.set("test_gradle_plugin")
-    debug.set(true)
     uploadEnabled.set(true)
 }

--- a/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/BuildReporter.kt
+++ b/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/BuildReporter.kt
@@ -3,42 +3,39 @@ package io.github.wzieba.tracks.plugin
 import io.github.wzieba.tracks.plugin.analytics.AnalyticsReporter
 import io.github.wzieba.tracks.plugin.analytics.Emojis.FAILURE_ICON
 import kotlinx.coroutines.runBlocking
+import org.gradle.api.logging.Logger
 import java.util.concurrent.TimeUnit
 
 class BuildReporter(
+    private val logger: Logger,
     private val analyticsReporter: AnalyticsReporter
 ) {
 
     @Suppress("TooGenericExceptionCaught")
-    fun report(buildData: BuildData, username: String?, customEventName: String?, debug: Boolean) {
+    fun report(buildData: BuildData, username: String?, customEventName: String?) {
         try {
-            reportMeasured(buildData, username, customEventName, debug)
+            reportMeasured(buildData, username, customEventName)
         } catch (ex: Exception) {
-            println("$FAILURE_ICON Build time reporting failed: $ex")
+            logger.warn("$FAILURE_ICON Build time reporting failed: $ex")
         }
     }
 
-    private fun reportMeasured(buildData: BuildData, username: String?, customEventName: String?, debug: Boolean) {
+    private fun reportMeasured(buildData: BuildData, username: String?, customEventName: String?) {
         val start = nowMillis()
 
-        reportInternal(buildData, username, customEventName, debug)
+        reportInternal(buildData, username, customEventName)
 
         val reportingOverhead = nowMillis() - start
-        if (debug) {
-            println(
-                "Reporting overhead: $reportingOverhead ms."
-            )
-        }
+        logger.info("Reporting overhead: $reportingOverhead ms.")
     }
 
     private fun reportInternal(
         buildData: BuildData,
         username: String?,
         customEventName: String?,
-        debug: Boolean
     ) {
         runBlocking {
-            analyticsReporter.report(buildData, username, customEventName, debug)
+            analyticsReporter.report(logger, buildData, username, customEventName)
         }
     }
 

--- a/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/BuildTimeListener.kt
+++ b/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/BuildTimeListener.kt
@@ -34,7 +34,6 @@ internal class BuildTimeListener(
                 buildData,
                 tracksExtension.username.orNull,
                 tracksExtension.customEventName.orNull,
-                tracksExtension.debug.getOrElse(false)
             )
         }
     }

--- a/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/BuildTimePlugin.kt
+++ b/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/BuildTimePlugin.kt
@@ -14,7 +14,7 @@ abstract class BuildTimePlugin : Plugin<Project> {
 
         val buildTimeListener = BuildTimeListener(
             buildDataFactory = BuildDataFactory,
-            buildReporter = BuildReporter(TracksReporter()),
+            buildReporter = BuildReporter(project.logger, TracksReporter()),
             tracksExtension = extension,
             includedBuilds = project.gradle.includedBuilds
         )

--- a/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/TracksExtension.kt
+++ b/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/TracksExtension.kt
@@ -13,9 +13,6 @@ abstract class TracksExtension @Inject constructor(project: Project) {
     val automatticProject: Property<AutomatticProject> = objects.property(AutomatticProject::class.java)
 
     @Optional
-    val debug: Property<Boolean> = objects.property(Boolean::class.java)
-
-    @Optional
     val uploadEnabled: Property<Boolean> = objects.property(Boolean::class.java)
 
     @Optional

--- a/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/analytics/AnalyticsReporter.kt
+++ b/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/analytics/AnalyticsReporter.kt
@@ -1,7 +1,13 @@
 package io.github.wzieba.tracks.plugin.analytics
 
 import io.github.wzieba.tracks.plugin.BuildData
+import org.gradle.api.logging.Logger
 
 interface AnalyticsReporter {
-    suspend fun report(event: BuildData, username: String?, customEventName: String?, debug: Boolean)
+    suspend fun report(
+        logger: Logger,
+        event: BuildData,
+        username: String?,
+        customEventName: String?,
+    )
 }

--- a/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/analytics/networking/TracksReporter.kt
+++ b/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/analytics/networking/TracksReporter.kt
@@ -8,9 +8,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.features.json.serializer.KotlinxSerializer
-import io.ktor.client.features.logging.EMPTY
 import io.ktor.client.features.logging.Logging
-import io.ktor.client.features.logging.SIMPLE
 import io.ktor.client.request.headers
 import io.ktor.client.request.post
 import io.ktor.client.statement.HttpResponse
@@ -19,7 +17,6 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.Logger
 import java.util.Locale
 import java.util.concurrent.TimeUnit.MILLISECONDS
@@ -39,7 +36,7 @@ class TracksReporter : AnalyticsReporter {
             install(Logging) {
                 this.logger = object : io.ktor.client.features.logging.Logger {
                     override fun log(message: String) {
-                        logger.debug( message)
+                        logger.debug(message)
                     }
                 }
                 level = io.ktor.client.features.logging.LogLevel.ALL
@@ -75,7 +72,6 @@ class TracksReporter : AnalyticsReporter {
                     )
                 }
             }
-
         }
         client.close()
     }

--- a/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/analytics/networking/TracksReporter.kt
+++ b/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/analytics/networking/TracksReporter.kt
@@ -67,7 +67,7 @@ class TracksReporter : AnalyticsReporter {
                         MILLISECONDS.toMinutes(buildTime),
                         MILLISECONDS.toSeconds(buildTime) - MINUTES.toSeconds(MILLISECONDS.toMinutes(buildTime))
                     )
-                    logger.quiet("$SUCCESS_ICON Build time report of $timeFormatted has been received by Tracks.")
+                    logger.lifecycle("$SUCCESS_ICON Build time report of $timeFormatted has been received by Tracks.")
                 }
                 else -> {
                     logger.warn(


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->
Closes: #8 

## 🚀 Description
<!-- Describe your changes in detail -->
This PR replaces use of `System.out.println` with Gradle's logger and removes `debug` parameter.

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Because we use Gradle's logger it's easier to request needed logging levels without any code changes. E.g. `./gradlew -q` will print no logs from plugin and `./gradlew --debug` - all possible logs.

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Run `./gradlew --debug` - assert you can see REST logs (look for `https://public-api.wordpress.com/rest/v1.1/tracks/record` in logs)
2. Run `./gradlew --quiet` - assert there's no logs from plugin
3. Run `./gradlew` - assert there is log about successful tracking
4. Turn off internet connection and run `./gradlew` - assert there's failure message

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
