### PR TITLE
Do not apply build time listener when plugin disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ rootProject {
 ```
 
 ## Configuration
-| Property | Default | Optional? | Description |
+| Property | Default | Required? | Description |
 | --- | --- | --- | --- |
-| automatticProject | null | false | Project that will determine event name
-| username | "anon" | true | Username associated with report |
-| uploadEnabled | true | true | Opt-out flag for sending reports to Tracks |
-| customEventName | null | true | Event name that overrides one set by `automatticProject`, should be used for debug purposes. |
-| debug | false | true | Show additional logs
+| automatticProject | null | yes | Project that will determine event name
+| enabled | null | yes | Enable or disable plugin |
+| username | "anon" | no | Username associated with report |
+| customEventName | null | no | Event name that overrides one set by `automatticProject`, should be used for debug purposes. |
+| debug | false | no | Show additional logs
 
 
 ## Result

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -5,6 +5,6 @@ plugins {
 
 tracks {
     automatticProject.set(io.github.wzieba.tracks.plugin.TracksExtension.AutomatticProject.WooCommerce)
+    enabled.set(true)
     customEventName.set("test_gradle_plugin")
-    uploadEnabled.set(true)
 }

--- a/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/BuildTimeListener.kt
+++ b/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/BuildTimeListener.kt
@@ -24,17 +24,19 @@ internal class BuildTimeListener(
     }
 
     override fun buildFinished(result: BuildResult) {
-        val buildData = buildDataFactory.buildData(
-            result,
-            taskExecutionStatisticsEventAdapter.statistics,
-            tracksExtension.automatticProject.get(),
-            includedBuilds.map(IncludedBuild::getName)
-        )
+        if (tracksExtension.enabled.get()) {
+            val buildData = buildDataFactory.buildData(
+                result,
+                taskExecutionStatisticsEventAdapter.statistics,
+                tracksExtension.automatticProject.get(),
+                includedBuilds.map(IncludedBuild::getName)
+            )
 
-        buildReporter.report(
-            buildData,
-            tracksExtension.username.orNull,
-            tracksExtension.customEventName.orNull,
-        )
+            buildReporter.report(
+                buildData,
+                tracksExtension.username.orNull,
+                tracksExtension.customEventName.orNull,
+            )
+        }
     }
 }

--- a/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/BuildTimeListener.kt
+++ b/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/BuildTimeListener.kt
@@ -18,7 +18,9 @@ internal class BuildTimeListener(
     override fun settingsEvaluated(gradle: Settings) = Unit
     override fun projectsLoaded(gradle: Gradle) = Unit
     override fun projectsEvaluated(gradle: Gradle) {
-        gradle.addListener(taskExecutionStatisticsEventAdapter)
+        if (tracksExtension.enabled.get()) {
+            gradle.addListener(taskExecutionStatisticsEventAdapter)
+        }
     }
 
     override fun buildFinished(result: BuildResult) {
@@ -29,12 +31,10 @@ internal class BuildTimeListener(
             includedBuilds.map(IncludedBuild::getName)
         )
 
-        if (tracksExtension.uploadEnabled.getOrElse(true)) {
-            buildReporter.report(
-                buildData,
-                tracksExtension.username.orNull,
-                tracksExtension.customEventName.orNull,
-            )
-        }
+        buildReporter.report(
+            buildData,
+            tracksExtension.username.orNull,
+            tracksExtension.customEventName.orNull,
+        )
     }
 }

--- a/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/TracksExtension.kt
+++ b/plugin-build/plugin/src/main/java/io/github/wzieba/tracks/plugin/TracksExtension.kt
@@ -12,8 +12,7 @@ abstract class TracksExtension @Inject constructor(project: Project) {
 
     val automatticProject: Property<AutomatticProject> = objects.property(AutomatticProject::class.java)
 
-    @Optional
-    val uploadEnabled: Property<Boolean> = objects.property(Boolean::class.java)
+    val enabled: Property<Boolean> = objects.property(Boolean::class.java)
 
     @Optional
     val username: Property<String> = objects.property(String::class.java)


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->
Closes: #9 

## 🚀 Description
<!-- Describe your changes in detail -->
This PR changes behaviour for users that disabled tracking - now, not only build time measurements won't be send but also not measured at all.

## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This change will save some build time for users who will not enable the plugin.

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Setting `enabled` to `true` should cause `✅ Build time report of Xm Ys has been received by Tracks.` after any Gradle task and setting it to `false` - lack of this message.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
